### PR TITLE
Add a new dist file in ES format but processed with babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git@github.com:grassator/insert-text-at-cursor.git"
   },
   "main": "dist/index.umd.js",
-  "module": "index.js",
+  "module": "dist/index.esm.js",
   "scripts": {
     "prepublishOnly": "npm run build",
     "watch": "rollup -c rollup.config.js --watch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import babel from "rollup-plugin-babel";
 
 const isProduction = process.env.NODE_ENV === "production";
 
-export default {
+export default [{
   input: "index.js",
   output: {
     file: `dist/index.umd${isProduction ? ".min" : ""}.js`,
@@ -12,4 +12,13 @@ export default {
     sourcemap: true
   },
   plugins: [babel(), isProduction && uglify()]
-};
+}, {
+  input: "index.js",
+  output: {
+    file: "dist/index.esm.js",
+    format: "es",
+    name: "insertTextAtCursor",
+    sourcemap: true
+  },
+  plugins: [babel()]
+}];


### PR DESCRIPTION
Closes #3
Closes #4

Note that I don't provide a minified ESM build here. There is 2 reasons for that:

- uglify (which is used currently) does not support `export` and so would break
- the module file is currently mostly used when bundling a project with webpack or rollup. And in this case, the final bundle should be minified anyway.