### PR TITLE
Fix HierachyRequestError in IE11

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,11 @@ export default function(input, text) {
     if (typeof input.setRangeText === "function") {
       input.setRangeText(text);
     } else {
+      // To make a change we just need a Range, not a Selection
+      const range = document.createRange();
+      const textNode = document.createTextNode(text);
+
       if (canManipulateViaTextNodes(input)) {
-        const textNode = document.createTextNode(text);
         let node = input.firstChild;
 
         // If textarea is empty, just insert the text
@@ -58,9 +61,6 @@ export default function(input, text) {
           let offset = 0;
           let startNode = null;
           let endNode = null;
-
-          // To make a change we just need a Range, not a Selection
-          const range = document.createRange();
 
           while (node && (startNode === null || endNode === null)) {
             const nodeLength = node.nodeValue.length;
@@ -83,13 +83,19 @@ export default function(input, text) {
           if (start !== end) {
             range.deleteContents();
           }
-
-          // Finally insert a new node. The browser will automatically
-          // split start and end nodes into two if necessary
-          range.insertNode(textNode);
         }
+      }
+
+      // If the node is a textarea and the range doesn't span outside the element
+      //
+      // Get the commonAncestorContainer of the selected range and test its type
+      // If the node is of type `#text` it means that we're still working with text nodes within our textarea element
+      // otherwise, if it's of type `#document` for example it means our selection spans outside the textarea.
+      if (canManipulateViaTextNodes(input) && range.commonAncestorContainer.nodeName === '#text') {
+        // Finally insert a new node. The browser will automatically split start and end nodes into two if necessary
+        range.insertNode(textNode);
       } else {
-        // For the text input the only way is to replace the whole value :(
+        // If the node is not a textarea or the range spans outside a textarea the only way is to replace the whole value
         const value = input.value;
         input.value = value.slice(0, start) + text + value.slice(end);
       }


### PR DESCRIPTION
Hello 👋

First of all, thanks a lot for putting this together.

We've been testing this solution as part of https://github.com/alphagov/paste-html-to-govspeak. ([preview deploy](https://alphagov.github.io/paste-html-to-govspeak/)) and we're running into an issue where IE11 fails with a `HierachyRequestError` when `insert-text-at-cursor` is being used in a textarea that ends with either 2 spaces or 1 new empty lines at the end of the content. The only workaround that I could find is to test for the `commonAncestorContainer` and make sure it's of type `#text` which ensures that the selection doesn't span outside the textarea. Let me know what you think or if you see a better way to deal with this.

### Steps to reproduce to replicate the issue
- Open IE 11
- Copy HTML from anywhere
- Go to https://alphagov.github.io/paste-html-to-govspeak/
- Press enter to have a new line
- Paste in the HTML again (this should now be stripped of markdown format and have a JS error)

The underlying error, HierachyRequestError, is caused by trying to insert a DOM node when it is not valid. See: https://developer.mozilla.org/en-US/docs/Web/API/DOMException#Error_codes for more